### PR TITLE
Don't use 'is' operator with integer literals (== preferred).

### DIFF
--- a/spydrnet_tmr/transformation/replication/organ_insertion.py
+++ b/spydrnet_tmr/transformation/replication/organ_insertion.py
@@ -661,7 +661,7 @@ class OrganInsertion:
     def find_key(self, instance):
         start_index = instance.name.find(self.replica_suffix)
         stop_index = start_index + len(self.replica_suffix) + 2
-        if start_index is -1:
+        if start_index == -1:
             key = ""
         else:
             key = instance.name[start_index:stop_index]


### PR DESCRIPTION
Python 3.10 helpfully emits the following warning:

```
/path/to/spydrnet-tmr/spydrnet_tmr/transformation/replication/organ_insertion.py:664: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if start_index is -1:

```

The current code does work as intended, but relies on small-number singletons ("interning") that are a Python implementation detail. For example:
```

>>> a = 1234567890
>>> b = 1234567890
>>> a is b
False
```

```
>>> c = -1
>>> d = -1
>>> c is d
True

```
So, this pull request should not alter behaviour - it just makes the code correct-er.